### PR TITLE
return error object in Promise.reject

### DIFF
--- a/src/wordhop.js
+++ b/src/wordhop.js
@@ -493,7 +493,7 @@ module.exports = function(apiKey, clientkey, config) {
             if (cb) {
                 cb(false);
             } 
-            return Promise.reject();
+            return Promise.reject(err);
         });
     };
 
@@ -509,7 +509,7 @@ module.exports = function(apiKey, clientkey, config) {
             if (cb) {
                 cb(false);
             } 
-            return Promise.reject();
+            return Promise.reject(err);
         });
     };
     


### PR DESCRIPTION
currently a failed `hopIn`/`hopOut` call returns an empty `Promise.reject()`. 

I'm using `blue-tape` and `nock` for testing and if my test fails (if I didn't properly mock the api call), `blue-tape` throws the following error:
```
Yonahs-MacBook-Pro-2:patient_bot Yonah$ tape lib/__test__/wordhop.js 
TAP version 13
# incoming(): sends message to wordhop, returns isBotPaused
ok 1 should be falsy
# outgoing(): sends outgoing message to wordhop
Warning: a promise was rejected with a non-error: [object Undefined]
    at /Users/Yonah/development/abi/abi_serverless/patient_bot/node_modules/wordhop/src/wordhop.js:512:28
    at tryOnImmediate (timers.js:543:15)
    at processImmediate [as _immediateCallback] (timers.js:523:5)

not ok 2 (unnamed assert)
  ---
    operator: fail
    at: tryCatcher (/Users/Yonah/development/abi/abi_serverless/patient_bot/node_modules/wordhop/node_modules/request-promise/node_modules/bluebird/js/release/util.js:16:23)
  ...
```

the solution was to pass the error response from catch to `Promise.reject`. I guess we could also just throw the error again, since you're already inside a promise. that might make more sense.