### PR TITLE
promise support for `checkForPaused`

### DIFF
--- a/src/wordhop.js
+++ b/src/wordhop.js
@@ -246,10 +246,16 @@ function WordhopBot(apiKey, serverRoot, path, socketServer, clientkey, token, us
         };
         return rp(data)
         .then(function (obj) {
-            cb(obj);
+            if (cb) {
+                cb(obj);
+            } 
+            return obj;
         })
         .catch(function (err) {
-            cb(null);
+            if (cb) {
+                cb(false);
+            } 
+            throw err;
         });
     }
 


### PR DESCRIPTION
make the api similar to other methods, where we check for the existence of a callback and then return the value, in case the user wants to use a promise